### PR TITLE
2.x GitHub action

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,6 +18,8 @@ jobs:
         run: docker-compose up -d && sleep 5
       - name: Install farmOS
         run: docker-compose exec -u www-data -T www drush site-install -y --db-url=pgsql://farm:farm@db/farm --account-pass=admin
+      - name: Install the farm_client module
+        run: docker-compose exec -u www-data -T www drush en -y farm_client
       - name: Run npm install
         run: npm install
       - name: Run tests

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,25 @@
+name: Run 2.x tests
+on:
+  push:
+    branches:
+      - '2.x'
+      - '2.x-**'
+
+jobs:
+  build:
+    name: Run tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+      - name: Create docker-compose.yml
+        run: curl https://raw.githubusercontent.com/farmOS/farmOS/2.x/docker/docker-compose.development.yml -o docker-compose.yml
+      - name: Start containers
+        run: docker-compose up -d && sleep 5
+      - name: Install farmOS
+        run: docker-compose exec -u www-data -T www drush site-install -y --db-url=pgsql://farm:farm@db/farm --account-pass=admin
+      - name: Run npm install
+        run: npm install
+      - name: Run tests
+        run: node node_modules/mocha/bin/mocha --recursive
+


### PR DESCRIPTION
This adds a GitHub Action for running tests whenever `2.x` or `2.x-*` branches are pushed. It runs a farmOS server in Docker, installs the `farm_client` module, and then runs `npm install` and `node node_modules/mocha/bin/mocha --recursive`.