### PR TITLE
Test assets with equipment instead of animals.

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install farmOS
         run: docker-compose exec -u www-data -T www drush site-install -y --db-url=pgsql://farm:farm@db/farm --account-pass=admin
       - name: Install the farm_client module
-        run: docker-compose exec -u www-data -T www drush en -y farm_client
+        run: docker-compose exec -u www-data -T www drush en -y farm_client && sleep 30
       - name: Run npm install
         run: npm install
       - name: Run tests

--- a/test/connect/asset.js
+++ b/test/connect/asset.js
@@ -11,7 +11,7 @@ describe('asset', function () {
       .then(() => {
         const asset = {
           id,
-          type: 'asset--animal',
+          type: 'asset--equipment',
           attributes: {
             name: 'Node Test Animal',
           },
@@ -22,7 +22,7 @@ describe('asset', function () {
         expect(response).to.have.nested.property('data.id', id);
         const asset = {
           id,
-          type: 'asset--animal',
+          type: 'asset--equipment',
           attributes: {
             name: 'Node Test Animal Revised',
             status: 'archived',
@@ -33,7 +33,7 @@ describe('asset', function () {
       .then(() => {
         const filter = {
           $or: [
-            { type: 'animal', status: 'archived' },
+            { type: 'equipment', status: 'archived' },
             { type: 'plant', status: 'active' },
           ],
         };
@@ -45,9 +45,9 @@ describe('asset', function () {
           .flatMap(r => r.data)
           .find(l => l.id === id);
         expect(asset).to.have.nested.property('attributes.name', 'Node Test Animal Revised');
-        return farm.asset.delete({ type: 'animal', id });
+        return farm.asset.delete({ type: 'equipment', id });
       })
-      .then(() => farm.asset.get({ filter: { type: 'animal', id } }))
+      .then(() => farm.asset.get({ filter: { type: 'equipment', id } }))
       .then((responses) => {
         const results = responses.flatMap(r => r.data);
         expect(results).to.have.lengthOf(0);


### PR DESCRIPTION
For the sake of simplicity in our base testing case, I've swapped out the `asset--animal` type for `asset--equipment`, because as @mstenta pointed out, animals require an additional field of `animal-type`. I didn't catch this in local tests because it's a recent change to the 2.x branch of farmOS. I'll need to update my local machine soon, but CI testing FTW!

I'm also leaving on the commit to wait 30 seconds between enabling the `farm_client` module and starting the tests. Not sure if this had anything to do with the failing tests in the first place, but seems like good practice regardless.